### PR TITLE
Add .gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Build outputs
+*.bmp
+*.o
+*.out
+*.exe
+*.a
+*.so
+mandelbrot_c
+mandelbrot_cuda
+mandelbrot_cpp_cuda
+mandelbulb_cuda


### PR DESCRIPTION
## Summary
- add a `.gitignore` at repository root
- ignore bitmap images, object files, and generated binaries

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841978c5aec8328aa56d70043e1e2d2