### PR TITLE
Update grayscale pixel assignment

### DIFF
--- a/mandelbrot.c
+++ b/mandelbrot.c
@@ -54,7 +54,8 @@ void mandelbrot_simd(uint32_t* image) {
             for (int i = 0; i < 8; ++i) {
                 int index = py * WIDTH + px + i;
                 int color = _mm256_extract_epi32(iter, i);
-                image[index] = (255 - (color * 255 / MAX_ITER)) | ((255 - (color * 255 / MAX_ITER)) << 8) | ((255 - (color * 255 / MAX_ITER)) << 16);
+                int gray = 255 - (color * 255 / MAX_ITER);
+                image[index] = gray | (gray << 8) | (gray << 16);
             }
         }
     }


### PR DESCRIPTION
## Summary
- streamline grayscale calculation in `mandelbrot.c`

## Testing
- `gcc -mavx2 -o mandelbrot mandelbrot.c -lm` *(fails: the last argument must be a 1-bit immediate)*

------
https://chatgpt.com/codex/tasks/task_e_6841978b9cfc8328b31df3171a94b282