### PR TITLE
Remove GMP usage from CUDA examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ To build the examples you will need:
 
 - **gcc** – for the plain C implementation using AVX intrinsics.
 - **nvcc** (CUDA Toolkit) – for the CUDA examples.
-- **gmp** development headers and library – required by the CUDA/C++ versions
-  that use the GNU Multiple Precision Arithmetic Library (`<gmp.h>`).
 - A C++ compiler such as **g++** (generally provided with the CUDA Toolkit when
   using `nvcc`).
 
@@ -36,11 +34,11 @@ gcc -O2 -mavx2 -std=c11 mandelbrot.c -o mandelbrot_c -lm
 
 ### mandelbrot.cu
 
-CUDA version that also relies on GMP for arbitrary precision arithmetic.
-Compile it with `nvcc` and link against the GMP library:
+CUDA version using double precision floating point numbers.
+Compile it with `nvcc`:
 
 ```bash
-nvcc -O2 mandelbrot.cu -o mandelbrot_cuda -lgmp
+nvcc -O2 mandelbrot.cu -o mandelbrot_cuda
 ```
 
 ### mandelbrot.cpp
@@ -49,7 +47,7 @@ Although this file has a `.cpp` extension it makes use of CUDA kernels. It can
 also be compiled with `nvcc`:
 
 ```bash
-nvcc -O2 mandelbrot.cpp -o mandelbrot_cpp_cuda -lgmp
+nvcc -O2 mandelbrot.cpp -o mandelbrot_cpp_cuda
 ```
 
 ### mandelbulb.cu

--- a/mandelbrot.cpp
+++ b/mandelbrot.cpp
@@ -1,4 +1,3 @@
-#include <gmp.h>
 #include <cuda_runtime.h>
 #include <cmath>
 #include <iostream>
@@ -6,98 +5,79 @@
 #define BLOCK_SIZE 128
 #define MAX_ITERATIONS 1000
 
-__global__ void mandelbrotKernel(mpf_t *x, mpf_t *y, int *iterations, int width, int height)
+__global__ void mandelbrotKernel(double *x, double *y, int *iterations, int width, int height)
 {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int i = idx % width;
     int j = idx / width;
 
-    mpf_t real, imag, temp, real2, imag2;
-    mpf_init(real);
-    mpf_init(imag);
-    mpf_init(temp);
-    mpf_init(real2);
-    mpf_init(imag2);
-
-    mpf_set(real, x[i]);
-    mpf_set(imag, y[j]);
+    double real = x[i];
+    double imag = y[j];
 
     int count = 0;
     while (count < MAX_ITERATIONS)
     {
-        mpf_mul(real2, real, real);
-        mpf_mul(imag2, imag, imag);
+        double real2 = real * real;
+        double imag2 = imag * imag;
 
-        if (mpf_cmp(real2 + imag2, (mpf_t)2.0) > 0)
+        if (real2 + imag2 > 4.0)
             break;
 
-        mpf_mul(temp, real, imag);
-        mpf_add(imag, temp, temp);
-        mpf_add(imag, imag, y[j]);
-
-        mpf_set(real, real2 - imag2 + x[i]);
+        double temp = real * imag;
+        imag = 2.0 * temp + y[j];
+        real = real2 - imag2 + x[i];
 
         count++;
     }
 
     iterations[idx] = count;
-
-    mpf_clear(real);
-    mpf_clear(imag);
-    mpf_clear(temp);
-    mpf_clear(real2);
-    mpf_clear(imag2);
 }
 
 int main()
 {
     int width = 800, height = 800;
-    mpf_t xmin, xmax, ymin, ymax, step;
-    mpf_init(xmin);
-    mpf_init(xmax);
-    mpf_init(ymin);
-    mpf_init(ymax);
-    mpf_init(step);
+    double xmin = -2.0;
+    double xmax = 1.0;
+    double ymin = -1.5;
+    double ymax = 1.5;
+    double step = (xmax - xmin) / width;
 
-    mpf_set_d(xmin, -2.0);
-    mpf_set_d(xmax, 1.0);
-    mpf_set_d(ymin, -1.5);
-    mpf_set_d(ymax, 1.5);
-    mpf_sub(step, xmax, xmin);
-    mpf_div_ui(step, step, width);
-
-    mpf_t *x, *y;
-    int *iterations;
-    cudaMalloc(&x, width * sizeof(mpf_t));
-    cudaMalloc(&y, height * sizeof(mpf_t));
-    cudaMalloc(&iterations, width * height * sizeof(int));
+    double *hx = new double[width];
+    double *hy = new double[height];
+    int *hIterations = new int[width * height];
 
     for (int i = 0; i < width; i++)
-    {
-        mpf_init(x[i]);
-        mpf_mul_ui(x[i], step, i);
-        mpf_add(x[i], x[i], xmin);
-    }
+        hx[i] = xmin + step * i;
 
     for (int j = 0; j < height; j++)
-    {
-        mpf_init(y[j]);
-        mpf_mul_ui(y[j], step, j);
-        mpf_add(y[j], y[j], ymin);
-    }
+        hy[j] = ymin + step * j;
 
-    dim3 block(BLOCK_SIZE, BLOCK_SIZE);
-    dim3 grid((width + BLOCK_SIZE - 1) / BLOCK_SIZE, (height + BLOCK_SIZE - 1) / BLOCK_SIZE);
-    mandelbrotKernel<<<(x, y, iterations, width, height)
+    double *x, *y;
+    int *iterations;
+    cudaMalloc(&x, width * sizeof(double));
+    cudaMalloc(&y, height * sizeof(double));
+    cudaMalloc(&iterations, width * height * sizeof(int));
+
+    cudaMemcpy(x, hx, width * sizeof(double), cudaMemcpyHostToDevice);
+    cudaMemcpy(y, hy, height * sizeof(double), cudaMemcpyHostToDevice);
+
+    dim3 block(BLOCK_SIZE);
+    dim3 grid((width * height + BLOCK_SIZE - 1) / BLOCK_SIZE);
+    mandelbrotKernel<<<grid, block>>>(x, y, iterations, width, height);
 
     cudaDeviceSynchronize();
 
+    cudaMemcpy(hIterations, iterations, width * height * sizeof(int), cudaMemcpyDeviceToHost);
     for (int i = 0; i < width * height; i++)
-        std::cout << iterations[i] << " ";
+        std::cout << hIterations[i] << " ";
 
     cudaFree(x);
     cudaFree(y);
     cudaFree(iterations);
+
+    delete[] hx;
+    delete[] hy;
+    delete[] hIterations;
 
     return 0;
 }

--- a/mandelbrot.cu
+++ b/mandelbrot.cu
@@ -1,4 +1,3 @@
-#include <gmp.h>
 #include <cuda_runtime.h>
 #include <cmath>
 #include <iostream>
@@ -6,98 +5,79 @@
 #define BLOCK_SIZE 128
 #define MAX_ITERATIONS 1000
 
-__global__ void mandelbrotKernel(mpf_t *x, mpf_t *y, int *iterations, int width, int height)
+__global__ void mandelbrotKernel(double *x, double *y, int *iterations, int width, int height)
 {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int i = idx % width;
     int j = idx / width;
 
-    mpf_t real, imag, temp, real2, imag2;
-    mpf_init(real);
-    mpf_init(imag);
-    mpf_init(temp);
-    mpf_init(real2);
-    mpf_init(imag2);
-
-    mpf_set(real, x[i]);
-    mpf_set(imag, y[j]);
+    double real = x[i];
+    double imag = y[j];
 
     int count = 0;
     while (count < MAX_ITERATIONS)
     {
-        mpf_mul(real2, real, real);
-        mpf_mul(imag2, imag, imag);
+        double real2 = real * real;
+        double imag2 = imag * imag;
 
-        if (mpf_cmp(real2 + imag2, (mpf_t)2.0) > 0)
+        if (real2 + imag2 > 4.0)
             break;
 
-        mpf_mul(temp, real, imag);
-        mpf_add(imag, temp, temp);
-        mpf_add(imag, imag, y[j]);
-
-        mpf_set(real, real2 - imag2 + x[i]);
+        double temp = real * imag;
+        imag = 2.0 * temp + y[j];
+        real = real2 - imag2 + x[i];
 
         count++;
     }
 
     iterations[idx] = count;
-
-    mpf_clear(real);
-    mpf_clear(imag);
-    mpf_clear(temp);
-    mpf_clear(real2);
-    mpf_clear(imag2);
 }
 
 int main()
 {
     int width = 800, height = 800;
-    mpf_t xmin, xmax, ymin, ymax, step;
-    mpf_init(xmin);
-    mpf_init(xmax);
-    mpf_init(ymin);
-    mpf_init(ymax);
-    mpf_init(step);
+    double xmin = -2.0;
+    double xmax = 1.0;
+    double ymin = -1.5;
+    double ymax = 1.5;
+    double step = (xmax - xmin) / width;
 
-    mpf_set_d(xmin, -2.0);
-    mpf_set_d(xmax, 1.0);
-    mpf_set_d(ymin, -1.5);
-    mpf_set_d(ymax, 1.5);
-    mpf_sub(step, xmax, xmin);
-    mpf_div_ui(step, step, width);
-
-    mpf_t *x, *y;
-    int *iterations;
-    cudaMalloc(&x, width * sizeof(mpf_t));
-    cudaMalloc(&y, height * sizeof(mpf_t));
-    cudaMalloc(&iterations, width * height * sizeof(int));
+    double *hx = new double[width];
+    double *hy = new double[height];
+    int *hIterations = new int[width * height];
 
     for (int i = 0; i < width; i++)
-    {
-        mpf_init(x[i]);
-        mpf_mul_ui(x[i], step, i);
-        mpf_add(x[i], x[i], xmin);
-    }
+        hx[i] = xmin + step * i;
 
     for (int j = 0; j < height; j++)
-    {
-        mpf_init(y[j]);
-        mpf_mul_ui(y[j], step, j);
-        mpf_add(y[j], y[j], ymin);
-    }
+        hy[j] = ymin + step * j;
 
-    dim3 block(BLOCK_SIZE, BLOCK_SIZE);
-    dim3 grid((width + BLOCK_SIZE - 1) / BLOCK_SIZE, (height + BLOCK_SIZE - 1) / BLOCK_SIZE);
-    mandelbrotKernel<<<grid.x, grid.y, block.x, block.y>>>(x, y, iterations, width, height);
+    double *x, *y;
+    int *iterations;
+    cudaMalloc(&x, width * sizeof(double));
+    cudaMalloc(&y, height * sizeof(double));
+    cudaMalloc(&iterations, width * height * sizeof(int));
+
+    cudaMemcpy(x, hx, width * sizeof(double), cudaMemcpyHostToDevice);
+    cudaMemcpy(y, hy, height * sizeof(double), cudaMemcpyHostToDevice);
+
+    dim3 block(BLOCK_SIZE);
+    dim3 grid((width * height + BLOCK_SIZE - 1) / BLOCK_SIZE);
+    mandelbrotKernel<<<grid, block>>>(x, y, iterations, width, height);
 
     cudaDeviceSynchronize();
 
+    cudaMemcpy(hIterations, iterations, width * height * sizeof(int), cudaMemcpyDeviceToHost);
     for (int i = 0; i < width * height; i++)
-        std::cout << iterations[i] << " ";
+        std::cout << hIterations[i] << " ";
 
     cudaFree(x);
     cudaFree(y);
     cudaFree(iterations);
+
+    delete[] hx;
+    delete[] hy;
+    delete[] hIterations;
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- switch CUDA Mandelbrot versions to double precision
- fix kernel launch syntax
- document CUDA build instructions without GMP

## Testing
- `nvcc -V` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841978a6ed08328b8e9e1b364bd78f2