### PR TITLE
Fix GPU kernel launch and precision types

### DIFF
--- a/mandelbrot.cpp
+++ b/mandelbrot.cpp
@@ -1,4 +1,3 @@
-#include <gmp.h>
 #include <cuda_runtime.h>
 #include <cmath>
 #include <iostream>
@@ -6,89 +5,57 @@
 #define BLOCK_SIZE 128
 #define MAX_ITERATIONS 1000
 
-__global__ void mandelbrotKernel(mpf_t *x, mpf_t *y, int *iterations, int width, int height)
+__global__ void mandelbrotKernel(double *x, double *y, int *iterations,
+                                  int width, int height)
 {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    int i = idx % width;
-    int j = idx / width;
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    int j = blockIdx.y * blockDim.y + threadIdx.y;
 
-    mpf_t real, imag, temp, real2, imag2;
-    mpf_init(real);
-    mpf_init(imag);
-    mpf_init(temp);
-    mpf_init(real2);
-    mpf_init(imag2);
+    if (i >= width || j >= height)
+        return;
 
-    mpf_set(real, x[i]);
-    mpf_set(imag, y[j]);
-
+    double real = x[i];
+    double imag = y[j];
+    double real2 = real * real;
+    double imag2 = imag * imag;
     int count = 0;
-    while (count < MAX_ITERATIONS)
+
+    while (count < MAX_ITERATIONS && real2 + imag2 <= 4.0)
     {
-        mpf_mul(real2, real, real);
-        mpf_mul(imag2, imag, imag);
+        imag = 2.0 * real * imag + y[j];
+        real = real2 - imag2 + x[i];
 
-        if (mpf_cmp(real2 + imag2, (mpf_t)2.0) > 0)
-            break;
-
-        mpf_mul(temp, real, imag);
-        mpf_add(imag, temp, temp);
-        mpf_add(imag, imag, y[j]);
-
-        mpf_set(real, real2 - imag2 + x[i]);
-
+        real2 = real * real;
+        imag2 = imag * imag;
         count++;
     }
 
-    iterations[idx] = count;
-
-    mpf_clear(real);
-    mpf_clear(imag);
-    mpf_clear(temp);
-    mpf_clear(real2);
-    mpf_clear(imag2);
+    iterations[j * width + i] = count;
 }
 
 int main()
 {
     int width = 800, height = 800;
-    mpf_t xmin, xmax, ymin, ymax, step;
-    mpf_init(xmin);
-    mpf_init(xmax);
-    mpf_init(ymin);
-    mpf_init(ymax);
-    mpf_init(step);
+    double xmin = -2.0, xmax = 1.0;
+    double ymin = -1.5, ymax = 1.5;
+    double stepx = (xmax - xmin) / width;
+    double stepy = (ymax - ymin) / height;
 
-    mpf_set_d(xmin, -2.0);
-    mpf_set_d(xmax, 1.0);
-    mpf_set_d(ymin, -1.5);
-    mpf_set_d(ymax, 1.5);
-    mpf_sub(step, xmax, xmin);
-    mpf_div_ui(step, step, width);
-
-    mpf_t *x, *y;
+    double *x, *y;
     int *iterations;
-    cudaMalloc(&x, width * sizeof(mpf_t));
-    cudaMalloc(&y, height * sizeof(mpf_t));
-    cudaMalloc(&iterations, width * height * sizeof(int));
+    cudaMallocManaged(&x, width * sizeof(double));
+    cudaMallocManaged(&y, height * sizeof(double));
+    cudaMallocManaged(&iterations, width * height * sizeof(int));
 
     for (int i = 0; i < width; i++)
-    {
-        mpf_init(x[i]);
-        mpf_mul_ui(x[i], step, i);
-        mpf_add(x[i], x[i], xmin);
-    }
+        x[i] = xmin + i * stepx;
 
     for (int j = 0; j < height; j++)
-    {
-        mpf_init(y[j]);
-        mpf_mul_ui(y[j], step, j);
-        mpf_add(y[j], y[j], ymin);
-    }
+        y[j] = ymin + j * stepy;
 
     dim3 block(BLOCK_SIZE, BLOCK_SIZE);
     dim3 grid((width + BLOCK_SIZE - 1) / BLOCK_SIZE, (height + BLOCK_SIZE - 1) / BLOCK_SIZE);
-    mandelbrotKernel<<<(x, y, iterations, width, height)
+    mandelbrotKernel<<<grid, block>>>(x, y, iterations, width, height);
 
     cudaDeviceSynchronize();
 

--- a/mandelbrot.cu
+++ b/mandelbrot.cu
@@ -1,4 +1,4 @@
-#include <gmp.h>
+
 #include <cuda_runtime.h>
 #include <cmath>
 #include <iostream>
@@ -6,89 +6,57 @@
 #define BLOCK_SIZE 128
 #define MAX_ITERATIONS 1000
 
-__global__ void mandelbrotKernel(mpf_t *x, mpf_t *y, int *iterations, int width, int height)
+__global__ void mandelbrotKernel(double *x, double *y, int *iterations,
+                                  int width, int height)
 {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    int i = idx % width;
-    int j = idx / width;
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    int j = blockIdx.y * blockDim.y + threadIdx.y;
 
-    mpf_t real, imag, temp, real2, imag2;
-    mpf_init(real);
-    mpf_init(imag);
-    mpf_init(temp);
-    mpf_init(real2);
-    mpf_init(imag2);
+    if (i >= width || j >= height)
+        return;
 
-    mpf_set(real, x[i]);
-    mpf_set(imag, y[j]);
-
+    double real = x[i];
+    double imag = y[j];
+    double real2 = real * real;
+    double imag2 = imag * imag;
     int count = 0;
-    while (count < MAX_ITERATIONS)
+
+    while (count < MAX_ITERATIONS && real2 + imag2 <= 4.0)
     {
-        mpf_mul(real2, real, real);
-        mpf_mul(imag2, imag, imag);
+        imag = 2.0 * real * imag + y[j];
+        real = real2 - imag2 + x[i];
 
-        if (mpf_cmp(real2 + imag2, (mpf_t)2.0) > 0)
-            break;
-
-        mpf_mul(temp, real, imag);
-        mpf_add(imag, temp, temp);
-        mpf_add(imag, imag, y[j]);
-
-        mpf_set(real, real2 - imag2 + x[i]);
-
+        real2 = real * real;
+        imag2 = imag * imag;
         count++;
     }
 
-    iterations[idx] = count;
-
-    mpf_clear(real);
-    mpf_clear(imag);
-    mpf_clear(temp);
-    mpf_clear(real2);
-    mpf_clear(imag2);
+    iterations[j * width + i] = count;
 }
 
 int main()
 {
     int width = 800, height = 800;
-    mpf_t xmin, xmax, ymin, ymax, step;
-    mpf_init(xmin);
-    mpf_init(xmax);
-    mpf_init(ymin);
-    mpf_init(ymax);
-    mpf_init(step);
+    double xmin = -2.0, xmax = 1.0;
+    double ymin = -1.5, ymax = 1.5;
+    double stepx = (xmax - xmin) / width;
+    double stepy = (ymax - ymin) / height;
 
-    mpf_set_d(xmin, -2.0);
-    mpf_set_d(xmax, 1.0);
-    mpf_set_d(ymin, -1.5);
-    mpf_set_d(ymax, 1.5);
-    mpf_sub(step, xmax, xmin);
-    mpf_div_ui(step, step, width);
-
-    mpf_t *x, *y;
+    double *x, *y;
     int *iterations;
-    cudaMalloc(&x, width * sizeof(mpf_t));
-    cudaMalloc(&y, height * sizeof(mpf_t));
-    cudaMalloc(&iterations, width * height * sizeof(int));
+    cudaMallocManaged(&x, width * sizeof(double));
+    cudaMallocManaged(&y, height * sizeof(double));
+    cudaMallocManaged(&iterations, width * height * sizeof(int));
 
     for (int i = 0; i < width; i++)
-    {
-        mpf_init(x[i]);
-        mpf_mul_ui(x[i], step, i);
-        mpf_add(x[i], x[i], xmin);
-    }
+        x[i] = xmin + i * stepx;
 
     for (int j = 0; j < height; j++)
-    {
-        mpf_init(y[j]);
-        mpf_mul_ui(y[j], step, j);
-        mpf_add(y[j], y[j], ymin);
-    }
+        y[j] = ymin + j * stepy;
 
     dim3 block(BLOCK_SIZE, BLOCK_SIZE);
     dim3 grid((width + BLOCK_SIZE - 1) / BLOCK_SIZE, (height + BLOCK_SIZE - 1) / BLOCK_SIZE);
-    mandelbrotKernel<<<grid.x, grid.y, block.x, block.y>>>(x, y, iterations, width, height);
+    mandelbrotKernel<<<grid, block>>>(x, y, iterations, width, height);
 
     cudaDeviceSynchronize();
 


### PR DESCRIPTION
## Summary
- replace GMP types with `double` in CUDA implementations
- fix kernel launch syntax and add missing semicolon
- clean up includes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68419789da848328980cd1c7eb1d577b